### PR TITLE
feat(new_list): expose --source parameter

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -177,11 +177,19 @@ const tools = [
   },
   {
     name: "new_list",
-    description: "Create a new reminder list.",
+    description:
+      "Create a new reminder list. Optionally specify the Reminders source (account) — typical values are 'iCloud' or 'On My Mac'. If omitted, the CLI uses the only source when there's one and errors when multiple sources exist.",
     inputSchema: {
       type: "object",
       required: ["name"],
-      properties: { name: { type: "string" } },
+      properties: {
+        name: { type: "string", description: "Name of the new list." },
+        source: {
+          type: "string",
+          description:
+            "Reminders source/account name (e.g. 'iCloud', 'On My Mac'). Required only when multiple sources exist.",
+        },
+      },
       additionalProperties: false,
     },
   },
@@ -287,9 +295,14 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
         };
       }
       case "new_list": {
-        await rcli(["new-list", a.name]);
+        const args = ["new-list", a.name];
+        if (a.source !== undefined) args.push("--source", a.source);
+        await rcli(args);
+        const detail = a.source ? ` (source=${a.source})` : "";
         return {
-          content: [{ type: "text", text: `created list: ${a.name}` }],
+          content: [
+            { type: "text", text: `created list: ${a.name}${detail}` },
+          ],
         };
       }
       default:

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -122,9 +122,24 @@ async function main() {
     log("initialize", !!init.result, JSON.stringify((init.result as any)?.serverInfo));
     c.notify("notifications/initialized");
 
-    // 1. tools/list
+    // 1. tools/list — count + key schema regression checks
     const tl = (await c.request("tools/list")).result as any;
-    log("tools/list", Array.isArray(tl?.tools) && tl.tools.length === 9, `${tl?.tools?.length} tools`);
+    const toolList = tl?.tools as any[];
+    log("tools/list", Array.isArray(toolList) && toolList.length === 9, `${toolList?.length} tools`);
+
+    const editTool = toolList?.find((t) => t.name === "edit");
+    log(
+      "edit schema includes notes",
+      !!editTool?.inputSchema?.properties?.notes,
+      Object.keys(editTool?.inputSchema?.properties ?? {}).join(","),
+    );
+
+    const newListTool = toolList?.find((t) => t.name === "new_list");
+    log(
+      "new_list schema includes source",
+      !!newListTool?.inputSchema?.properties?.source,
+      Object.keys(newListTool?.inputSchema?.properties ?? {}).join(","),
+    );
 
     // 2. list_lists — must include TEST_LIST
     const lists = JSON.parse(extractText(await c.call("list_lists"))) as string[];


### PR DESCRIPTION
Closes #2.

## Summary

The `new_list` tool now accepts an optional `source` parameter that maps to the CLI's `--source` flag, letting callers pick which Reminders source/account the new list lands in (e.g. `iCloud` vs `On My Mac`).

When omitted, the tool defers to the CLI's default behavior — uses the only source when there's one, errors when multiple sources exist and none was specified.

## Changes

- `index.ts` — `new_list` schema gains `source` (optional string) with description; handler appends `--source <value>` when provided.
- `scripts/smoke.ts` — two new schema-regression checks:
  - `edit schema includes notes` (guards #1)
  - `new_list schema includes source` (guards #2)

## Why no runtime smoke for new_list?

Same reason `new_list` was skipped in the original smoke test: `reminders-cli` has no `delete-list` subcommand, so creating a sentinel list would leave cruft on the user's machine. The schema check is the proportionate guard here.

## Test plan

- [x] `bun run scripts/smoke.ts` — 15/15 passing locally
- [ ] Verify in a fresh Claude session that `new_list` accepts a `source` argument
- [ ] Verify `new_list` with multiple sources but no `source` arg still errors as before (CLI behavior)